### PR TITLE
use nullmailer instead of ssmtp

### DIFF
--- a/roles/mail/handlers/main.yml
+++ b/roles/mail/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: restart nullmailer
+  service: name=nullmailer state=restarted
+
 - name: restart postfix
   service: name=postfix state=restarted
 

--- a/roles/mail/tasks/mailleaf.yml
+++ b/roles/mail/tasks/mailleaf.yml
@@ -1,12 +1,22 @@
 # install a simpel smtp server that will redirect all mail to
 # {{maiL_relayhost}}
 ---
-- name: install ssmtp
-  apt: name=ssmtp state=installed
+- name: install nullmailer
+  apt: name=nullmailer state=installed
 
-- name: purge postfix
+- name: start nullmailer
+  service: name=nullmailer state=started enabled=true
+
+- name: purge other MTAs
   apt: name=postfix state=absent purge=true
+  with_items:
+    - postfix
+    - ssmtp
 
-- name: install ssmtp config
-  template: src=ssmtp.conf.j2 dest=/etc/ssmtp/ssmtp.conf
+- name: fix mailname
+  template: src=mailname.j2 dest=/etc/mailname
+  notify: restart nullmailer
 
+- name: install nullmail config
+  template: src=nullmailer.remotes.j2 dest=/etc/nullmailer/remotes
+  notify: restart nullmailer

--- a/roles/mail/templates/mailname.j2
+++ b/roles/mail/templates/mailname.j2
@@ -1,0 +1,1 @@
+{{ansible_fqdn}}

--- a/roles/mail/templates/nullmailer.remotes.j2
+++ b/roles/mail/templates/nullmailer.remotes.j2
@@ -1,0 +1,1 @@
+{{mail.relay_host}}


### PR DESCRIPTION
nullmailer implements local queuing, so it won't instantly fail when the
smtp proxy is down for a little while