### PR TITLE
Create Comanage CMuid, filter attributes

### DIFF
--- a/environments/vm/group_vars/comanage.yml
+++ b/environments/vm/group_vars/comanage.yml
@@ -38,7 +38,7 @@ comanage_proxy_db_name: "scz"
 
 idp_mellon_path: /etc/apache2/mellon/satosa
 idp_metadata_url: "https://proxy.{{base_domain}}/md/SamlIdP.xml"
-idp_attribute: "urn:oid:1.3.6.1.4.1.5923.1.1.1.6"
+idp_attribute: "cmuid"
 idp_extract_certificate: True
 
 portal_hostname: "{{ sp_hostname }}"

--- a/roles/comanage_idp/tasks/main.yml
+++ b/roles/comanage_idp/tasks/main.yml
@@ -27,5 +27,6 @@
     dest: "{{ idp_metadata_path }}"
     owner: www-data
     mode: 0600
+    force: yes
     validate_certs: no
 

--- a/roles/satosa/files/internal_attributes.yaml
+++ b/roles/satosa/files/internal_attributes.yaml
@@ -70,3 +70,6 @@ attributes:
     saml:
       - 'urn:mace:dir:attribute-def:eduPersonEntitlement'
       - 'urn:oid:1.3.6.1.4.1.5923.1.1.1.7'
+  cmuid:
+    saml:
+      - 'cmuid'

--- a/roles/satosa/tasks/main.yml
+++ b/roles/satosa/tasks/main.yml
@@ -113,6 +113,11 @@
         src: attribute_filter.yaml.j2
         dest: "{{ satosa_env_dir }}/plugins/micro_services/attribute_filter.yaml"
 
+    - name: Create custom_uid.yaml definition
+      template:
+        src: custom_uid.yaml.j2
+        dest: "{{ satosa_env_dir }}/plugins/micro_services/custom_uid.yaml"
+
     - name: Create static directory
       file: path="{{ satosa_env_dir }}/static" state=directory mode=0755
 

--- a/roles/satosa/templates/attribute_filter.yaml.j2
+++ b/roles/satosa/templates/attribute_filter.yaml.j2
@@ -3,7 +3,7 @@ name: AttributeFilter
 config:
     attribute_allow:
         default:
-            default:
+            'http://{{hostnames.comanage}}/registry/auth/sp/metadata':
                 "":
                    - ""
 #    attribute_deny:

--- a/roles/satosa/templates/custom_uid.yaml.j2
+++ b/roles/satosa/templates/custom_uid.yaml.j2
@@ -1,0 +1,8 @@
+module: satosa.micro_services.custom_uid.CustomUID
+name: CustomUID
+config:
+    select:
+        - eduPersonPrincipalName
+        - eduPersonTargetedID
+    couid: cmuid
+

--- a/roles/satosa/templates/proxy_conf.yaml.j2
+++ b/roles/satosa/templates/proxy_conf.yaml.j2
@@ -17,10 +17,11 @@ FRONTEND_MODULES:
 MICRO_SERVICES:
   - "plugins/micro_services/custom_logging_service.yaml"
   - "plugins/micro_services/custom_alias.yaml"
+  - "plugins/micro_services/r_and_s_acl.yaml"
+  - "plugins/micro_services/custom_uid.yaml"
   - "plugins/micro_services/attribute_filter.yaml"
   #- "plugins/micro_services/db_acl.yaml"
   - "plugins/micro_services/db_attributes_store.yaml"
-  - "plugins/micro_services/r_and_s_acl.yaml"
   - "plugins/micro_services/consent.yaml"
 USER_ID_HASH_SALT: "{{ satosa_user_id_hash_salt }}"
 LOGGING:


### PR DESCRIPTION
Lets satosa create cmuid, filter all outgoing attributes except to comanage. Let comanage consume cmuid as REMOTE_USER.