### PR TITLE
Fix for LDAP deploy: the eduMember schema was referenced with in lowe…

### DIFF
--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -127,7 +127,7 @@
     owner: "{{ ldap_user }}"
     group: "{{ ldap_user }}"
     url: "{{ ldapPublicKeySchema_url }}"
-    dest: "{{ ldap_schema_dir }}"
+    dest: "{{ ldap_schema_dir }}/ {{ ldapPublicKey }}.schema"
   when: ldappkstat.stat.exists == False
 
 - name: Convert LdapPublicKey schema to ldif format
@@ -142,7 +142,7 @@
     owner: "{{ ldap_user }}"
     group: "{{ ldap_user }}"
     url: "{{ eduMemberSchema_url }}"
-    dest: "{{ ldap_schema_dir }}"
+    dest: "{{ ldap_schema_dir }}/{{ eduMember }}.schema"
   when: edumemberstat.stat.exists == False
 
 - name: Convert eduMember schema to ldif format
@@ -157,7 +157,7 @@
 - name: Check if eduPerson schema is already present
   shell: >
     ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b 'cn=schema,cn=config' '(cn=*)' dn
-    | grep 'cn={[0123456789]\+}eduperson,cn=schema,cn=config'
+    | grep -i 'cn={[0123456789]\+}eduperson,cn=schema,cn=config'
   failed_when: not [0, 1]
   register:
     eduPersonSchemaPresent
@@ -176,7 +176,7 @@
 - name: Check if the ldapPublicKey schema is already present
   shell: >
     ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b 'cn=schema,cn=config' '(cn=*)' dn
-    | grep 'cn={[0-9]\+}openssh-lpk-openldap,cn=schema,cn=config'
+    | grep -i 'cn={[0-9]\+}openssh-lpk-openldap,cn=schema,cn=config'
   failed_when: not [0, 1]
   register:
     ldapPublicKeyTask
@@ -192,7 +192,7 @@
 - name: Check if the eduMember schema is already present
   shell: >
     ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b 'cn=schema,cn=config' '(cn=*)' dn
-    | grep 'cn={[0-9]\+}eduMember,cn=schema,cn=config'
+    | grep -i 'cn={[0-9]\+}edumember,cn=schema,cn=config'
   failed_when: not [1, 2]
   register:
     eduMemberTask

--- a/roles/ldap/vars/ldap.yml
+++ b/roles/ldap/vars/ldap.yml
@@ -16,7 +16,7 @@ ldapPKS1: https://raw.githubusercontent.com/AndriiGrytsenko/
 ldapPKS2: openssh-ldap-publickey/master/misc/openssh-lpk-openldap.schema
 ldapPublicKeySchema_url: "{{ ldapPKS1 }}{{ ldapPKS2 }}"
 
-eduMember: edumember
+eduMember: eduMember
 eduMember_ldif: "{{ eduMember }}.ldif"
 eduMember_host: https://raw.githubusercontent.com
 eduMember_path: /Internet2/grouper/master/apacheds-ldappc-schema/src/main/schema/eduMember.schema


### PR DESCRIPTION
Fix for LDAP deploy: the eduMember schema was referenced with in lower case, causing the conversion of an empty file to ldif, which resulted in an empty schema configuration, which caused problems when provisioning. Fix changes the case of the schema file, forces the external download to an explicit filename and greps case-insensitive on objectclass definitions (which are case-insensitive)