### PR TITLE
Add example encrypted assertion setup for Saml2Backend

### DIFF
--- a/roles/client-saml-idp/templates/saml20-sp-remote.php.j2
+++ b/roles/client-saml-idp/templates/saml20-sp-remote.php.j2
@@ -74,7 +74,7 @@ $metadata['https://{{ hostnames.proxy }}/md/SamlSP.xml'] = array (
   array (
     0 =>
     array (
-      'encryption' => false,
+      'encryption' => true,
       'signing' => true,
       'type' => 'X509Certificate',
       'X509Certificate' => '{{ saml_ts_cert.cert }}',
@@ -82,6 +82,7 @@ $metadata['https://{{ hostnames.proxy }}/md/SamlSP.xml'] = array (
   ),
   'validate.authnrequest' => false,
   'saml20.sign.assertion' => true,
+  'assertion.encryption' => true,
 );
 $metadata['https://{{ hostnames.proxy }}/md/SamlMirrorSP.xml/SamlIdP/aHR0cHM6Ly9zcC10ZXN0LnNjei12bS5uZXQvc2FtbC9tb2R1bGUucGhwL3NhbWwvc3AvbWV0YWRhdGEucGhwL2RlZmF1bHQtc3A='] = array (
   'entityid' => 'https://{{ hostnames.proxy }}/md/SamlMirrorSP.xml/SamlIdP/aHR0cHM6Ly9zcC10ZXN0LnNjei12bS5uZXQvc2FtbC9tb2R1bGUucGhwL3NhbWwvc3AvbWV0YWRhdGEucGhwL2RlZmF1bHQtc3A=',

--- a/roles/satosa/templates/saml2_backend.yaml.j2
+++ b/roles/satosa/templates/saml2_backend.yaml.j2
@@ -5,6 +5,9 @@ config:
   sp_config:
     key_file: certs/backend.key
     cert_file: certs/backend.crt
+    encryption_keypairs:
+      - key_file : certs/frontend.key
+        cert_file : certs/frontend.crt
     organization:
       display_name: "{{ satosa_md.organisation.display_name }}"
       name: "{{ satosa_md.organisation.name }}"


### PR DESCRIPTION
This adds encrypted assertion demonstration between Satosa Saml2Backend and simplesamlphp Satosa non-transparent SP configuration