### PR TITLE
Fix comanage filtering entityID

### DIFF
--- a/roles/satosa/templates/attribute_filter_post.yaml.j2
+++ b/roles/satosa/templates/attribute_filter_post.yaml.j2
@@ -8,7 +8,7 @@ config:
                     - ""
     attribute_deny:
         default:
-            'http://{{hostnames.comanage}}/registry/auth/sp/metadata':
+            'https://{{hostnames.comanage}}/registry/auth/sp/metadata':
                 "^$":
                     - ""
             default:

--- a/roles/satosa/templates/attribute_filter_pre.yaml.j2
+++ b/roles/satosa/templates/attribute_filter_pre.yaml.j2
@@ -3,7 +3,7 @@ name: AttributeFilterPre
 config:
     attribute_allow:
         default:
-            'http://{{hostnames.comanage}}/registry/auth/sp/metadata':
+            'https://{{hostnames.comanage}}/registry/auth/sp/metadata':
                 "":
                    - ""
             default:


### PR DESCRIPTION
It seems comanage moved from http to https entityID. This breaks satosa entityID based attribute filtering.