### PR TITLE
Added voPerson objectclass (exportable in COmanage 3.2.0)

### DIFF
--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -89,6 +89,11 @@
     path: "{{ ldap_schema_dir }}/{{ eduMember_ldif }}"
   register: edumemberstat
 
+- name: Check for presence of voPerson ldif
+  stat:
+    path: "{{ ldap_schema_dir }}/{{ voPerson_ldif }}"
+  register: vopersonstat
+
 - name: Fetch the eduPerson schema
   become: true
   get_url:
@@ -148,7 +153,16 @@
   become_user: "{{ ldap_user }}"
   when: edumemberstat.stat.exists == False
 
-# OpenLDAP does not like adding exisiting entries again. Only add the
+- name: Fetch voPerson ldif
+  become: true
+  get_url:
+    owner: "{{ ldap_user }}"
+    group: "{{ ldap_user }}"
+    url: "{{ voPersonLdif_url }}"
+    dest: "{{ ldap_schema_dir }}/{{ voPerson }}.ldif"
+  when: vopersonstat.stat.exists == False
+
+# OpenLDAP does not like adding existing entries again. Only add the
 # schema if it has not been added already. This does not yet take care
 # of changes in the eduPerson schema.
 - name: Check if eduPerson schema is already present
@@ -201,6 +215,22 @@
     -f "{{ ldap_schema_dir }}/{{ eduMember_ldif }}"
     -D "cn=config" -w "{{ ldap_password }}"
   when: eduMemberTask.stdout == ""
+
+- name: Check if the voPerson schema is already present
+  shell: >
+    ldapsearch -Q -LLL -Y EXTERNAL -H ldapi:/// -b 'cn=schema,cn=config' '(cn=*)' dn
+    | grep -i 'cn={[0-9]\+}voperson,cn=schema,cn=config'
+  failed_when: not [1, 2]
+  register:
+    voPersonTask
+
+- name: Ensure the voPerson schema is added to LDAP
+  become: true
+  command: >
+    ldapadd -Q -Y EXTERNAL -H ldapi:///
+    -f "{{ ldap_schema_dir }}/{{ voPerson_ldif }}"
+    -D "cn=config" -w "{{ ldap_password }}"
+  when: voPersonTask.stdout == ""
 
 - name: Check if DIT has been created before
   command:

--- a/roles/ldap/vars/ldap.yml
+++ b/roles/ldap/vars/ldap.yml
@@ -21,3 +21,9 @@ eduMember_ldif: "{{ eduMember }}.ldif"
 eduMember_host: https://raw.githubusercontent.com
 eduMember_path: /Internet2/grouper/master/apacheds-ldappc-schema/src/main/schema/eduMember.schema
 eduMemberSchema_url: "{{ eduMember_host }}{{ eduMember_path }}"
+
+voPerson: voPerson
+voPerson_ldif: "{{ voPerson }}.ldif"
+voPerson_host: https://raw.githubusercontent.com
+voPerson_path: /voperson/voperson/master/schema/openldap/voperson.ldif
+voPersonLdif_url: "{{ voPerson_host }}{{ voPerson_path }}"


### PR DESCRIPTION
Added voPerson objectclass. Apparently this is supported in COmanage 3.2.0 and I needed this for testing an upstream PR. I figured we would need this in the deploy as well at some point, although the LdapFixedProvisioner needs updates for that.