### PR TITLE
Rotate proxy daemon logs

### DIFF
--- a/roles/cmservice/files/logrotate_cmservice
+++ b/roles/cmservice/files/logrotate_cmservice
@@ -1,0 +1,12 @@
+/var/log/cmservice.log
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}

--- a/roles/cmservice/files/rsyslog_cmservice.conf
+++ b/roles/cmservice/files/rsyslog_cmservice.conf
@@ -1,0 +1,2 @@
+if $programname == 'cmservice' then /var/log/cmservice.log
+if $programname == 'cmservice' then ~

--- a/roles/cmservice/tasks/main.yml
+++ b/roles/cmservice/tasks/main.yml
@@ -72,5 +72,16 @@
     dest: "/etc/systemd/system/cmservice.service"
     remote_src: yes
 
+- name: Copy rsyslog config
+  copy: >
+    src=rsyslog_cmservice.conf
+    dest=/etc/rsyslog.d/cmservice.conf
+  notify: "restart rsyslog"
+
+- name: Copy logrotate config
+  copy: >
+    src=logrotate_cmservice
+    dest=/etc/logrotate.d/cmservice
+
 - name: restart CMservice
   systemd: daemon_reload=yes name=cmservice state=restarted enabled=yes

--- a/roles/cmservice/templates/cmservice.service.j2
+++ b/roles/cmservice/templates/cmservice.service.j2
@@ -9,6 +9,9 @@ WorkingDirectory={{ cmservice_env_dir }}
 Environment="CMSERVICE_CONFIG={{ cmservice_env_dir }}/settings.cfg"
 ExecStart={{ cmservice_env_dir }}/bin/gunicorn -b{{ cmservice_host }}:{{ cmservice_port }} cmservice.service.run:app
 Restart=on-abort
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=cmservice
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pyff/files/logrotate_pyffd
+++ b/roles/pyff/files/logrotate_pyffd
@@ -1,0 +1,12 @@
+/var/log/pyffd.log
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}

--- a/roles/pyff/tasks/main.yml
+++ b/roles/pyff/tasks/main.yml
@@ -96,6 +96,11 @@
     dest=/etc/rsyslog.d/pyffd.conf
   notify: "restart rsyslog"
 
+- name: Copy logrotate config
+  copy: >
+    src=logrotate_pyffd
+    dest=/etc/logrotate.d/pyffd
+
 - name: restart pyff
   systemd: daemon_reload=yes name=pyff state=restarted enabled=yes
 

--- a/roles/satosa/files/logrotate_satosa
+++ b/roles/satosa/files/logrotate_satosa
@@ -1,0 +1,12 @@
+/var/log/satosa.log
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                reload rsyslog >/dev/null 2>&1 || true
+        endscript
+}

--- a/roles/satosa/tasks/main.yml
+++ b/roles/satosa/tasks/main.yml
@@ -292,5 +292,10 @@
     dest=/etc/rsyslog.d/satosa.conf
   notify: "restart rsyslog"
 
+- name: Copy logrotate config
+  copy: >
+    src=logrotate_satosa
+    dest=/etc/logrotate.d/satosa
+
 - name: restart SATOSA
   systemd: daemon_reload=yes name=satosa state=restarted enabled=yes


### PR DESCRIPTION
This PR adds long overdue logrotate configuration for proxy services and redirects cmservice logs to it's own logs.