### PR TITLE
Fix for additional space in name of LPK schema file, which creates an…

### DIFF
--- a/roles/ldap/tasks/main.yml
+++ b/roles/ldap/tasks/main.yml
@@ -129,7 +129,7 @@
     owner: "{{ ldap_user }}"
     group: "{{ ldap_user }}"
     url: "{{ ldapPublicKeySchema_url }}"
-    dest: "{{ ldap_schema_dir }}/ {{ ldapPublicKey }}.schema"
+    dest: "{{ ldap_schema_dir }}/{{ ldapPublicKey }}.schema"
   when: ldappkstat.stat.exists == False
 
 - name: Convert LdapPublicKey schema to ldif format


### PR DESCRIPTION
Removed space in filename, which caused an empty ldif file