### PR TITLE
Fixed an ldap handler name and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Science Collaboration Zone (SCZ) project offers ann Identity Management solution
 for research collaborations.  It is a middleware solution for
-researchers, which allows them to 
+researchers, which allows them to
 
 - log in using credentials from their university;
 - handle (Identity and Access Management (IAM) for their collaborations;
@@ -63,7 +63,7 @@ To get started, do the following:
     - libvirt: `vagrant up --provider libvirt --provision` 
     - virtualbox: `vagrant up --provider virtualbox --provision`
 
-    This will start 5 VMs (each requires 786MB of memory) and run the ansible
+    This will start 6 VMs (each requires 786MB of memory) and run the ansible
     playbook to install the SCZ on those VMs.
 - when the deploy finishes, you should be able to browse to
   <https://comanage.scz-vm.net> and login using the default platform admin

--- a/roles/ldap/handlers/main.yml
+++ b/roles/ldap/handlers/main.yml
@@ -12,6 +12,6 @@
   service:  name=slapd state=restarted enabled=yes
   listen: "restart slapd"
 
-- name: systemd daemon-reload
+- name: systemctl daemon-reload
   systemd: daemon_reload=yes
 


### PR DESCRIPTION
LDAP handler name still contained 'systemd' instead of 'systemctl'.

README.md wrongly stated that there are 5 instead of 6 VMs.