### PR TITLE
Use --build-arg for setting SSH pub key.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,8 @@ if ARGV[0] == "up"  and  ( !sshkeypriv.exist?  or  !sshkeypub.exist? )
     File.chmod(0600,sshkeypriv)
 end
 
+ssh_pub_key = sshkeypub.open("r").read()
+
 ENV['COMPOSE_PROJECT_NAME']="scz"
 
 domain = "scz-vm.net"
@@ -142,7 +144,7 @@ Vagrant.configure("2") do |config|
             m.vm.provider "docker" do |dk|
                 dk.name = machinename
                 dk.build_dir ="./docker"
-                dk.build_args = ["-t", "scz" ]
+                dk.build_args = ["-t", "scz", "--build-arg", "ssh_pub_key=#{ssh_pub_key}" ]
                 dk.remains_running = true
                 dk.has_ssh = true
                 create_args = [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:stretch
 MAINTAINER SURFnet <info@surfnet.nl>
 
+ARG ssh_pub_key
+
 # add the backports repository so we get the right version of systemd
 ADD sources.list /etc/apt/sources.list
 
@@ -39,7 +41,7 @@ WORKDIR /home/vagrant
 
 # Configure SSH access
 RUN mkdir -p /home/vagrant/.ssh
-RUN echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" > /home/vagrant/.ssh/authorized_keys
+RUN echo "${ssh_pub_key}" >> /home/vagrant/.ssh/authorized_keys
 RUN chown -R vagrant: /home/vagrant/.ssh
 RUN echo -n 'vagrant:vagrant' | chpasswd
 


### PR DESCRIPTION
Deze patch verwijdert de static SSH key in de Dockerfile en gebruikt --build-arg om de huidige pub ssh key van vagrant te krijgen.