### PR TITLE
Restore php composer require for oidc module

### DIFF
--- a/roles/client-google-idp/tasks/main.yml
+++ b/roles/client-google-idp/tasks/main.yml
@@ -34,27 +34,11 @@
       Listen {{ google_test_port }}
   notify: restart Apache
 
-- name: Checkout fork of openidconnect module
-  git:
-    repo: "{{ simplesaml_oidc_repo_url }}"
-    dest: "{{ simplesaml_oidc_src_dir }}"
-    version: "{{ simplesaml_oidc_repo_version }}"
-    accept_hostkey: "yes"
-    force: "yes"
-
-- name: Add local openidconnect module repository
-  shell: >
-    { rm composer.json;
-    jq '.["repositories"] = [{"type": "vcs", "url": "{{ simplesaml_oidc_src_dir }}"}]' >
-    composer.json; } < composer.json
-  args:
-    chdir: "{{ simplesaml_project_dir }}/simplesaml"
-
 - name: Install OIDC module
   composer:
     working_dir: "{{ simplesaml_project_dir }}/simplesaml"
     command: require
-    arguments: scz/simplesamlphp-module-openidconnect dev-master
+    arguments: bradjonesllc/simplesamlphp-module-openidconnect dev-master
     optimize_autoloader: False
 
 - name: Insert Google authsource


### PR DESCRIPTION
This (un)fix restores the old composer require way of installing oidc module, because upstream accepted my PR  \0/.