### PR TITLE
Added SamlSource OIS plugin from SCZ repository

### DIFF
--- a/roles/comanage_plugins/defaults/main.yml
+++ b/roles/comanage_plugins/defaults/main.yml
@@ -2,3 +2,4 @@
 comanage_plugin_zoneprovisioner_version: "HEAD"
 comanage_plugin_ldapfixedprovisioner_version: "HEAD"
 comanage_plugin_emailprovisioner_version: "HEAD"
+comanage_plugin_samlsource_version: "HEAD"

--- a/roles/comanage_plugins/vars/comanage_plugins.yml
+++ b/roles/comanage_plugins/vars/comanage_plugins.yml
@@ -12,6 +12,9 @@ comanage_git_plugins:
   - name: "EmailProvisioner"
     src: "https://github.com/SURFscz/COmanage-emailprovisioner.git"
     version: "{{comanage_plugin_emailprovisioner_version}}"
+  - name: "SamlSource"
+    src: "https://github.com/SURFscz/COmanage-samlsource.git"
+    version: "{{comanage_plugin_samlsource_version}}"
 
 comanage_plugin_configurations:
   - { src: ldapfixedprovisioner.php.j2, dest: ldapfixedprovisioner.php }


### PR DESCRIPTION
This introduces the SamlSource plugin in the default SCZ COmanage registry deploy. The SamlSource plugin does not work properly until PR#7 of the SCZ comanage registry has been included.