### PR TITLE
[finishes #157350531] Aanpassing aan LFP configuratie om groupOfNames…

### DIFF
--- a/roles/comanage_plugins/templates/ldapfixedprovisioner.php.j2
+++ b/roles/comanage_plugins/templates/ldapfixedprovisioner.php.j2
@@ -31,7 +31,8 @@ $config=array(
       'eduPerson',              # optional
       'posixAccount',           # optional
       'ldapPublicKey',          # optional
-      'posixGroup',             # optional
+      'groupOfNames',           # optional
+#     'posixGroup',             # optional
       'eduMember',              # optional
     ),
     'person' => array(
@@ -50,25 +51,25 @@ $config=array(
 #     'postalCode' => 'office',             # optional
     ),
     'inetOrgPerson' => array(
-#     'givenName' => 'official',     # optional
-     'displayName' => 'preferred',  # optional
-     'o' => TRUE,                   # optional
-     'mail' => TRUE,                # optional
-#     'mobile' => 'mobile',          # optional
+#     'givenName' => 'official',        # optional
+      'displayName' => 'preferred',     # optional
+      'o' => TRUE,                      # optional
+      'mail' => TRUE,                   # optional
+#     'mobile' => 'mobile',             # optional
 #     'employeeNumber' => 'enterprise', # optional
-#     'employeeType' => TRUE,        # optional
-#     'roomNumber' => TRUE,          # optional
-     'uid' => 'uid;person',                # optional
+#     'employeeType' => TRUE,           # optional
+#     'roomNumber' => TRUE,             # optional
+      'uid' => 'uid;person',            # optional
     ),
     'eduPerson' => array(
-#     'eduPersonAffiliation' => TRUE,               # optional
+#     'eduPersonAffiliation' => TRUE,              # optional
      'eduPersonEntitlement' => TRUE,               # optional
-#     'eduPersonNickname' => 'official',            # optional
-#     'eduPersonOrcid' => TRUE   ,                   # optional
+#     'eduPersonNickname' => 'official',           # optional
+#     'eduPersonOrcid' => TRUE   ,                 # optional
      'eduPersonPrincipalName' => 'eppn;org',       # optional
-#     'eduPersonPrincipalNamePrior' => 'eppn;org',  # optional
-#     'eduPersonScopedAffiliation' => TRUE,         # optional
-#     'eduPersonUniqueId' => 'enterprise',          # optional
+#     'eduPersonPrincipalNamePrior' => 'eppn;org', # optional
+#     'eduPersonScopedAffiliation' => TRUE,        # optional
+#     'eduPersonUniqueId' => 'enterprise',         # optional
     ),
     'posixAccount' => array(
       'uidNumber' => TRUE,     # required
@@ -85,14 +86,16 @@ $config=array(
       'cn' => TRUE,            # required
       'gidNumber' => TRUE,     # required
 #     'userPassword' => TRUE,  # optional
-#     'memberUID' => TRUE,     # optional
+      'memberUID' => TRUE,     # optional
 #     'description' => TRUE,   # optional
     ),
     'groupOfNames' => array(
       'cn' => TRUE,          # required
       'member' => TRUE,      # required
-#     'owner' => TRUE,       # optional
-     'description' => TRUE, # optional
+      'o' => TRUE,           # optional
+#     'ou' => TRUE,          # optional
+      'owner' => TRUE,       # optional
+      'description' => TRUE, # optional
     ),
     'eduMember' => array(
       'isMemberOf' => TRUE,   # optional


### PR DESCRIPTION
Aanpassing aan LFP configuratie om groupOfNames (met o attribuut) uit te genereren ipv posixGroup ten behoeve van CO->COU->CoGroup hierarchy.

Dit kan los van de redeployment van HEAD van de LFP verder (is slechts een configuratie wijziging)