### PR TITLE
Fix configuration changes in pam-websso

### DIFF
--- a/roles/pam_websso/templates/pam_websso.json.j2
+++ b/roles/pam_websso/templates/pam_websso.json.j2
@@ -2,7 +2,6 @@
     "ports": {
         "clients": {{ pam_websso.daemon.ports.clients }}
         },
-    "sso_server": "{{hostnames.pam}}",
-    "sso_url": "https://{{hostnames.pam}}/login/%s"
+    "sso_server": "{{hostnames.pam}}"
 }
 

--- a/roles/pam_websso_daemon/templates/websso_daemon.json.j2
+++ b/roles/pam_websso_daemon/templates/websso_daemon.json.j2
@@ -3,7 +3,8 @@
         "clients": {{ pam_websso.daemon.ports.clients }},
         "command": {{ pam_websso.daemon.ports.command }},
         "web": {{ pam_websso.daemon.ports.web }}
-        },
+    },
+    "url": "https://{{hostnames.pam}}/",
     "user_attribute": "{{ pam_websso.daemon.user_attribute }}",
     "strict": false,
     "debug": true,


### PR DESCRIPTION
I changed the responsability for creating websso-url to the websso-daemon, which is the logical place to do it. This commit reflects the necessary changes in the pam suite configuration(s)