### PR TITLE
Disable getty spawning in docker VM's

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,11 @@ CMD ["/lib/systemd/systemd"]
 RUN apt-get install -y openssh-server python2.7 python3 python sudo locales
 RUN update-locale
 RUN systemctl enable ssh.service
-RUN systemctl disable getty\@tty1.service
+# DIE getty, DIE!
+RUN systemctl disable getty@
+RUN systemctl disable getty.target
+RUN rm /lib/systemd/system/multi-user.target.wants/getty.target
+RUN rm /lib/systemd/system/getty.target.wants/getty-static.service
 RUN systemctl disable systemd-timesyncd.service
 
 # sshd services in all containers


### PR DESCRIPTION
Although the Travis CPU load was fixed, getty's were still spawned for Linux hosts that needed a tty console locally. This is fixed by removing the multi-user.target.wants/getty.target