### PR TITLE
Revert oidcmodule fork back to upstream

### DIFF
--- a/roles/client-microsoft-idp/defaults/main.yml
+++ b/roles/client-microsoft-idp/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-simplesaml_oidc_repo_url: https://github.com/SURFscz/simplesamlphp-module-openidconnect.git
+simplesaml_oidc_repo_url: https://github.com/BradJonesLLC/simplesamlphp-module-openidconnect.git
 simplesaml_oidc_repo_version: master
 simplesaml_oidc_src_dir: "{{ simplesaml_project_dir }}/module-oidc"


### PR DESCRIPTION
Reverts the oidcmodule source back to upstream
I didn't check deployability, but have good faith:
Upstream merged our PR
No other commits after our PR