### PR TITLE
Attempt at streamlining pam-websso pip installation

### DIFF
--- a/roles/pam_websso/tasks/main.yml
+++ b/roles/pam_websso/tasks/main.yml
@@ -7,10 +7,19 @@
   with_items:
     - libnss-ldap
     - libpam-python
-    - python-pip
+    - pamtester
     - libxml2-dev
     - libxmlsec1-dev
-    - pamtester
+    - build-essential
+    - python-dev
+    - python-pip
+    - python-openssl
+    - python-setuptools
+    - python-wheel
+    - python-twisted
+    - python-openssl
+    - python-defusedxml
+    - python-isodate
 
 - name: fetch PAM WebSSO from {{ pam_websso.repo_url }}, version {{ pam_websso.repo_version }}
   git:
@@ -24,7 +33,7 @@
 - name: install PAM WebSSO
   pip:
     name: "{{ pam_websso.project_dir }}"
-    state: latest
+    #state: latest
   when: pam_websso_git.changed
 
 - name: install PAM WebSSO configuration


### PR DESCRIPTION
pam-websso can't be installed in virtualenv (at least not the PAM module) and python-saml has a hard dependancy on dm.xmlsec.binding which needs to compile cython bindings against a pip'ed version of python-lxml. The debian package of lxml contains an invalid etree_api.h header file (wrong name).