### PR TITLE
Fix metadata xslt IdP filtering

### DIFF
--- a/roles/metadata/files/idps.xsl
+++ b/roles/metadata/files/idps.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
     xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
     version="1.0">
@@ -14,6 +15,10 @@
         </xsl:copy>
     </xsl:template>
 
+    <xsl:template match="md:EntityDescriptor[not(md:IDPSSODescriptor)]" />
+
     <xsl:template match="md:SPSSODescriptor" />
+
+    <xsl:template match="ds:Signature" />
 
 </xsl:stylesheet>


### PR DESCRIPTION
idps.xsl contained a mistake that created invalid metadata for some IDPSSO/SPSSO entities, this PR fixes that plus removes the useless signature on the fly.