### PR TITLE
Make sure all pip dependencies are updated

### DIFF
--- a/roles/pyff/tasks/main.yml
+++ b/roles/pyff/tasks/main.yml
@@ -46,7 +46,7 @@
       shell: "bin/pip list --outdated --format=freeze | \
               grep -v '^\\-e' | \
               cut -d = -f 1 | \
-              xargs -n1 bin/pip install -U"
+              xargs -rn1 bin/pip install -U"
       args:
         chdir: "{{ pyff_env_dir }}"
 

--- a/roles/pyff/tasks/main.yml
+++ b/roles/pyff/tasks/main.yml
@@ -42,6 +42,14 @@
         #executable: pip2
       when: fetch_pyff.changed
 
+    - name: Update all dependencies
+      shell: "bin/pip list --outdated --format=freeze | \
+              grep -v '^\\-e' | \
+              cut -d = -f 1 | \
+              xargs -n1 bin/pip install -U"
+      args:
+        chdir: "{{ pyff_env_dir }}"
+
     - name: Create pyFF mdq configuration
       template: src=mdq.fd.j2
                 dest="{{ pyff_env_dir }}/mdq.fd"


### PR DESCRIPTION
It turns out ansible pip state: latest does not update package dependencies. To make sure every pyff deploy uses the most recent version of packages, a seperate pip install -U on outdated packages needs to be performed.