### PR TITLE
Make sure all pip dependencies are updated

### DIFF
--- a/roles/cmservice/tasks/main.yml
+++ b/roles/cmservice/tasks/main.yml
@@ -40,6 +40,14 @@
         state: latest
         #executable: pip3
 
+    - name: Update pip dependencies
+      shell: "bin/pip list --outdated --format=freeze | \
+              grep -v '^\\-e' | \
+              cut -d = -f 1 | \
+              xargs -rn1 bin/pip install -U"
+      args:
+        chdir: "{{ cmservice_env_dir }}"
+
     - name: Create CMservice  settings.cfg configuration
       template: src=settings.cfg.j2
                 dest="{{ cmservice_env_dir }}/settings.cfg"

--- a/roles/pyff/tasks/main.yml
+++ b/roles/pyff/tasks/main.yml
@@ -42,6 +42,14 @@
         #executable: pip2
       when: fetch_pyff.changed
 
+    - name: Update pip dependencies
+      shell: "bin/pip list --outdated --format=freeze | \
+              grep -v '^\\-e' | \
+              cut -d = -f 1 | \
+              xargs -rn1 bin/pip install -U"
+      args:
+        chdir: "{{ pyff_env_dir }}"
+
     - name: Create pyFF mdq configuration
       template: src=mdq.fd.j2
                 dest="{{ pyff_env_dir }}/mdq.fd"

--- a/roles/satosa/tasks/main.yml
+++ b/roles/satosa/tasks/main.yml
@@ -65,6 +65,14 @@
         state: latest
       when: satosa_git.changed
 
+    - name: Update pip dependencies
+      shell: "bin/pip list --outdated --format=freeze | \
+              grep -v '^\\-e' | \
+              cut -d = -f 1 | \
+              xargs -rn1 bin/pip install -U"
+      args:
+        chdir: "{{ satosa_env_dir }}"
+
     - name: >
         install SATOSA microservices from {{ satosa_microservices_src_dir }}
         to {{ satosa_env_dir }}


### PR DESCRIPTION
It turns out ansible pip state: latest does not update package dependencies. To make sure every pyff deploy uses the most recent version of packages, a seperate pip install -U on outdated packages needs to be performed.

This PR supersedes https://github.com/SURFscz/SCZ-deploy/pull/134