### PR TITLE
Adjust ansible roles for new PAM WebSSO HTTP transport

### DIFF
--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -27,7 +27,6 @@ sp_test_port: 82
 oidc_test_port: 83
 google_test_port: 84
 pam_clients_port: 8123
-pam_web_port: 8125
 orcid_test_port: 85
 ms_test_port: 86
 
@@ -72,10 +71,6 @@ loadbalancer:
     http: true
     backend_hosts: "{{groups['vm-client']}}"
     backend_port: "{{google_test_port}}"
-  - hostname: "{{hostnames.pam}}"
-    http: true
-    backend_hosts: "{{groups['vm-ldap']}}"
-    backend_port: "{{pam_web_port}}"
   - hostname: "{{hostnames.orcid}}"
     http: true
     backend_hosts: "{{groups['vm-client']}}"
@@ -90,7 +85,6 @@ loadbalancer:
     backend_hosts: "{{groups['vm-ldap']}}"
     backend_port: 389
   - hostname: "{{hostnames.pam}}"
-    http: false
-    frontend_port: "{{pam_clients_port}}"
+    http: true
     backend_hosts: "{{groups['vm-ldap']}}"
     backend_port: "{{pam_clients_port}}"

--- a/provision.yml
+++ b/provision.yml
@@ -74,7 +74,7 @@
   roles:
     - { role: ldap, tags: ['ldap'] }
     - { role: ldap_clients, tags: ['ldap', 'ldap_clients'] }
-#    - { role: pam_websso_daemon,  tags: ['client','websso-daemon'] }
+    - { role: pam_websso_daemon,  tags: ['client','websso-daemon'] }
 
 - hosts:
     - proxy

--- a/roles/pam_websso/tasks/main.yml
+++ b/roles/pam_websso/tasks/main.yml
@@ -6,6 +6,7 @@
     install_recommends: no
   with_items:
     - libnss-ldap
+    - nscd
     - libpam-python
     - pamtester
     - libxml2-dev

--- a/roles/pam_websso/templates/pam_websso.json.j2
+++ b/roles/pam_websso/templates/pam_websso.json.j2
@@ -1,7 +1,4 @@
 {
-    "ports": {
-        "clients": {{ pam_websso.daemon.ports.clients }}
-        },
-    "sso_server": "{{hostnames.pam}}"
+    "sso_server": "https://{{hostnames.pam}}"
 }
 


### PR DESCRIPTION
PAM WebSSO is now 100% HTTP transport only.