### PR TITLE
Migrate libnss-ldap to libnss-ldapd

### DIFF
--- a/roles/pam_websso/defaults/main.yml
+++ b/roles/pam_websso/defaults/main.yml
@@ -3,7 +3,3 @@ pam_websso:
   repo_url: "https://github.com/SURFscz/pam-websso.git"
   repo_version: "master"
   project_dir: "/opt/pam-websso"
-  server: "localhost"
-  daemon:
-    ports:
-      clients: 8123

--- a/roles/pam_websso/tasks/main.yml
+++ b/roles/pam_websso/tasks/main.yml
@@ -5,8 +5,7 @@
     state: present
     install_recommends: no
   with_items:
-    - libnss-ldap
-    - nscd
+    - libnss-ldapd
     - libpam-python
     - pamtester
     - libxml2-dev
@@ -34,42 +33,31 @@
 - name: install PAM WebSSO
   pip:
     name: "{{ pam_websso.project_dir }}"
-    #state: latest
   when: pam_websso_git.changed
-
-- name: install PAM WebSSO configuration
-  template:
-    src: "pam-websso.j2"
-    dest: "/etc/pam.d/pam-websso"
 
 - name: install PAM WebSSO settings
   template:
     src: "pam_websso.json.j2"
     dest: "{{ pam_websso.project_dir }}/pam_websso.json"
 
-- name: install NSS LDAP settings
+- name: install nslcd config
   template:
-    src: "libnss-ldap.conf.j2"
-    dest: "/etc/libnss-ldap.conf"
-
-- name: install NSS LDAP root pwd
-  template:
-    src: "pam_ldap.secret.j2"
-    dest: "/etc/pam_ldap.secret"
+    src: "nslcd.conf.j2"
+    dest: "/etc/nslcd.conf"
 
 - name: Copy PAM mkhomedir conf
   copy:
     src: "mkhomedir"
     dest: "/usr/share/pam-configs"
 
-- name: Add LDAP nsswitch lookup
+- name: Add LDAP nsswitch passwd lookup
   replace:
     path: /etc/nsswitch.conf
     regexp: '^(passwd:.*compat)$'
     replace: '\1 ldap'
     backup: yes
 
-- name: Add LDAP nsswitch lookup
+- name: Add LDAP nsswitch group lookup
   replace:
     path: /etc/nsswitch.conf
     regexp: '^(group:.*compat)$'
@@ -91,6 +79,3 @@
     replace: >-
       \n\nsession required pam_mkhomedir.so umask=0022 skel=/etc/skel\1
     backup: yes
-
-- name: Restart nscd server
-  service: name=nscd state=restarted

--- a/roles/pam_websso/templates/libnss-ldap.conf.j2
+++ b/roles/pam_websso/templates/libnss-ldap.conf.j2
@@ -1,8 +1,0 @@
-base {{ client_ldap.basedn }}
-uri ldaps://{{ hostnames.ldap }}
-binddn {{ client_ldap.binddn }}
-rootbinddn {{ client_ldap.binddn }}
-bindpw {{ client_ldap_password }}
-scope sub
-bind_policy soft
-

--- a/roles/pam_websso/templates/nslcd.conf.j2
+++ b/roles/pam_websso/templates/nslcd.conf.j2
@@ -1,0 +1,33 @@
+# /etc/nslcd.conf
+# nslcd configuration file. See nslcd.conf(5)
+# for details.
+
+# The user and group nslcd should run as.
+uid nslcd
+gid nslcd
+
+# The location at which the LDAP server(s) should be reachable.
+uri ldaps://{{ hostnames.ldap }}
+
+# The search base that will be used for all queries.
+base {{ client_ldap.basedn }}
+
+# The LDAP protocol version to use.
+#ldap_version 3
+
+# The DN to bind with for normal lookups.
+binddn {{ client_ldap.binddn }}
+bindpw {{ client_ldap_password }}
+
+# The DN used for password modifications by root.
+#rootpwmoddn cn=admin,dc=example,dc=com
+
+# SSL options
+#ssl off
+#tls_reqcert never
+tls_cacertfile /etc/ssl/certs/ca-certificates.crt
+
+# The search scope.
+#scope sub
+
+map group member sczMember

--- a/roles/pam_websso/templates/pam-websso.j2
+++ b/roles/pam_websso/templates/pam-websso.j2
@@ -1,2 +1,0 @@
-auth sufficient pam_python.so {{ pam_websso.project_dir }}/pam_websso.py
-

--- a/roles/pam_websso/templates/pam_ldap.secret.j2
+++ b/roles/pam_websso/templates/pam_ldap.secret.j2
@@ -1,1 +1,0 @@
-{{ client_ldap_password }}

--- a/roles/pam_websso/templates/pam_websso.json.j2
+++ b/roles/pam_websso/templates/pam_websso.json.j2
@@ -1,4 +1,3 @@
 {
     "sso_server": "https://{{hostnames.pam}}"
 }
-


### PR DESCRIPTION
This PR migrates libnss-ldap based nss to libnss-ldapd, so that ldaps connections work:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=579647