### PR TITLE
Fixes R&S filter sn internal attribute mapping

### DIFF
--- a/roles/satosa/templates/r_and_s_acl.yaml.j2
+++ b/roles/satosa/templates/r_and_s_acl.yaml.j2
@@ -6,6 +6,6 @@ config:
     edupersontargetedid: eduPersonTargetedID
     displayname: displayName
     givenname: givenName
-    sn: surname
+    sn: sn
     mail: mail
   access_denied: '/static/r_and_s_failed'


### PR DESCRIPTION
R&S was still configured to look at old surname internal attribute.