### PR TITLE
Fix nsswitch.conf update tasks

### DIFF
--- a/roles/pam_websso/tasks/main.yml
+++ b/roles/pam_websso/tasks/main.yml
@@ -79,3 +79,16 @@
     replace: >-
       \n\nsession required pam_mkhomedir.so umask=0022 skel=/etc/skel\1
     backup: yes
+
+- name: Check for ChallengeResponseAuthentication in sshd
+  shell: grep 'ChallengeResponseAuthentication yes' /etc/ssh/sshd_config
+  register: cra_check
+  ignore_errors: true
+
+- name: Enable ssh ChallengeResponseAuthentication
+  replace:
+    path: /etc/ssh/sshd_config
+    regexp: '(\nUsePAM yes)\n\n'
+    replace: '\1\nChallengeResponseAuthentication yes\n\n'
+    backup: yes
+  when: cra_check is failed

--- a/roles/pam_websso/tasks/main.yml
+++ b/roles/pam_websso/tasks/main.yml
@@ -53,14 +53,14 @@
 - name: Add LDAP nsswitch passwd lookup
   replace:
     path: /etc/nsswitch.conf
-    regexp: '^(passwd:.*compat)$'
+    regexp: '^(passwd:.*systemd)$'
     replace: '\1 ldap'
     backup: yes
 
 - name: Add LDAP nsswitch group lookup
   replace:
     path: /etc/nsswitch.conf
-    regexp: '^(group:.*compat)$'
+    regexp: '^(group:.*systemd)$'
     replace: '\1 ldap'
     backup: yes
 


### PR DESCRIPTION
For some obscure reason my latest docker deploy had the passwd: and group: lines end on 'systemd' instead of 'compat', so the find/replace nsswitch.conf tasks failed to add 'ldap' at the end.

Also, sshd 'ChallengeResponseAuthentication yes' doesn't seem to be default anymore, or I missed it because of manual installation attempts before.