### PR TITLE
Separate metadata from pyFF venv

### DIFF
--- a/roles/pyff/defaults/main.yml
+++ b/roles/pyff/defaults/main.yml
@@ -5,6 +5,7 @@ http_proto: https
 pyff_repo_url: "https://github.com/SURFscz/pyFF.git"
 pyff_repo_version: "master"
 pyff_project_dir: "/opt/pyff"
+pyff_metadata_dir: "{{ pyff_project_dir }}/metadata"
 pyff_src_dir: "{{ pyff_project_dir }}/pyff-src"
 pyff_env_dir: "{{ pyff_project_dir }}/pyff-env"
 

--- a/roles/pyff/tasks/main.yml
+++ b/roles/pyff/tasks/main.yml
@@ -23,6 +23,9 @@
 - name: Create project directory
   file: path={{ pyff_project_dir }} state=directory mode=0755 owner=pyff
 
+- name: Create metadata directory
+  file: path={{ pyff_metadata_dir }} state=directory mode=0755 owner=pyff
+
 - block:
     # requirements.txt can be generated from virtualenv/bin/pip freeze
     - name: Generate requirements.txt.j2 from template

--- a/roles/pyff/templates/mdq.fd.j2
+++ b/roles/pyff/templates/mdq.fd.j2
@@ -29,7 +29,7 @@
        - {{m}}
 {% endfor %}
 {% endif %}
-       - /opt/pyff/pyff-env/metadata/
+       - {{ pyff_metadata_dir }}
     - break
 - when request:
     - select


### PR DESCRIPTION
By default metadata will live in /opt/pyff/metadata