### PR TITLE
Remove SATOSA mapper dir work-around

### DIFF
--- a/environments/vm/group_vars/proxy.yml
+++ b/environments/vm/group_vars/proxy.yml
@@ -9,7 +9,7 @@ firewall_v4_incoming:
 
 # SATOSA configuration
 satosa_repo_url: "https://github.com/SURFscz/SATOSA.git"
-satosa_repo_version: "scz-poc"
+satosa_repo_version: "scz"
 satosa_project_dir: "/opt/satosa"
 satosa_src_dir: "{{ satosa_project_dir }}/satosa-src"
 satosa_env_dir: "{{ satosa_project_dir }}/satosa-env"

--- a/roles/satosa/defaults/main.yml
+++ b/roles/satosa/defaults/main.yml
@@ -7,6 +7,10 @@ comange_entityid: "{{http_proto}}://{{hostnames.comanage}}/registry/auth/sp/meta
 satosa_repo_url: "https://github.com/SURFscz/SATOSA.git"
 satosa_repo_version: "scz-poc"
 satosa_project_dir: "/opt/satosa"
+satosa_client_dir: "{{ satosa_project_dir }}/clients"
+satosa_metadata_dir: "{{ satosa_project_dir }}/metadata"
+satosa_static_dir: "{{ satosa_project_dir }}/static"
+satosa_log_dir: "{{ satosa_project_dir }}/log"
 satosa_src_dir: "{{ satosa_project_dir }}/satosa-src"
 satosa_env_dir: "{{ satosa_project_dir }}/satosa-env"
 

--- a/roles/satosa/defaults/main.yml
+++ b/roles/satosa/defaults/main.yml
@@ -5,7 +5,7 @@ comange_entityid: "{{http_proto}}://{{hostnames.comanage}}/registry/auth/sp/meta
 
 # SATOSA configuration
 satosa_repo_url: "https://github.com/SURFscz/SATOSA.git"
-satosa_repo_version: "scz-poc"
+satosa_repo_version: "scz"
 satosa_project_dir: "/opt/satosa"
 satosa_client_dir: "{{ satosa_project_dir }}/clients"
 satosa_metadata_dir: "{{ satosa_project_dir }}/metadata"

--- a/roles/satosa/files/gen_metadata
+++ b/roles/satosa/files/gen_metadata
@@ -1,5 +1,0 @@
-#!/bin/sh
-. bin/activate
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
-satosa-saml-metadata --dir metadata --split-module proxy_conf.yaml certs/signing.key certs/signing.crt

--- a/roles/satosa/tasks/main.yml
+++ b/roles/satosa/tasks/main.yml
@@ -193,21 +193,6 @@
         dest: "{{ satosa_env_dir }}/satosa.service"
         mode: 0644
 
-    - name: Create mapper directory
-      file: path="{{ satosa_env_dir }}/mapper" state=directory mode=0755
-
-    - name: Copy empty mapper config
-      copy:
-        src: "{{ item }}"
-        dest: "{{ satosa_env_dir }}/mapper/{{ item }}"
-        mode: 0755
-      with_items:
-        - __init__.py
-        - basic.py
-        - uri.py
-        - unspecified.py
-        - shibboleth.py
-
     - name: Create metadata directory
       file: path="{{ satosa_metadata_dir }}" state=directory mode=0755 owner=satosa
 

--- a/roles/satosa/tasks/main.yml
+++ b/roles/satosa/tasks/main.yml
@@ -120,7 +120,7 @@
         dest: "{{ satosa_env_dir }}/plugins/micro_services/custom_uid.yaml"
 
     - name: Create static directory
-      file: path="{{ satosa_env_dir }}/static" state=directory mode=0755
+      file: path="{{ satosa_static_dir }}" state=directory mode=0755
 
     - name: Create custom_alias.yaml definition
       template:
@@ -135,7 +135,7 @@
     - name: Copy error and info pages to static alias directory
       copy:
         src: "{{ item }}"
-        dest: "{{ satosa_env_dir }}/static/{{ item }}"
+        dest: "{{ satosa_static_dir }}/{{ item }}"
       with_items:
         - info
         - error
@@ -143,10 +143,12 @@
         - r_and_s_failed
 
     - name: Create MongoDB database satosa with collection clients
-      shell: mongo satosa --eval "db.createCollection('clients')"
+      shell: mongo satosa --quiet --eval "db.createCollection('clients')"
+      register: result
+      changed_when: (result.stdout | from_json).ok == 1
 
-    - name: Create var logging directory
-      file: path="{{ satosa_env_dir }}/var" state=directory mode=0755
+    - name: Create logging directory
+      file: path="{{ satosa_log_dir }}" state=directory mode=0755
 
     - name: Create certs directory
       file: path="{{ satosa_env_dir }}/certs" state=directory mode=0755
@@ -207,15 +209,15 @@
         - shibboleth.py
 
     - name: Create metadata directory
-      file: path="{{ satosa_env_dir }}/metadata" state=directory mode=0755
+      file: path="{{ satosa_metadata_dir }}" state=directory mode=0755 owner=satosa
 
-    - name: Create clients.d directory
-      file: path="{{ satosa_env_dir }}/oidc_clients" state=directory mode=0755
+    - name: Create client directory
+      file: path="{{ satosa_client_dir }}" state=directory mode=0755 owner=satosa
 
     - name: Copy clients.json example file
       template:
         src: clients.json.j2
-        dest: "{{ satosa_env_dir }}/oidc_clients/default.json"
+        dest: "{{ satosa_client_dir }}/default.json"
         mode: 0755
 
     - name: Create sync_clients script
@@ -225,20 +227,20 @@
         mode: 0755
 
     - name: Insert OIDC clients
-      shell: ./sync_clients oidc_clients
-      args:
-        chdir: "{{ satosa_env_dir }}"
+      shell: "{{ satosa_env_dir }}/sync_clients {{ satosa_client_dir }}"
+      changed_when: false
 
     - name: Copy metadata generating script
-      copy:
-        src: gen_metadata
+      template:
+        src: gen_metadata.j2
         dest: "{{ satosa_env_dir }}/gen_metadata"
         mode: 0755
 
     - name: Generate metadata
-      shell: ./gen_metadata
+      shell: "{{ satosa_env_dir }}/gen_metadata {{ satosa_metadata_dir }}"
       args:
         chdir: "{{ satosa_env_dir }}"
+      changed_when: false
 
   become: "yes"
   become_user: satosa
@@ -285,3 +287,4 @@
 
 - name: restart SATOSA
   systemd: daemon_reload=yes name=satosa state=restarted enabled=yes
+  changed_when: false

--- a/roles/satosa/templates/custom_alias.yaml.j2
+++ b/roles/satosa/templates/custom_alias.yaml.j2
@@ -2,5 +2,5 @@ module: scz-micro_services.custom_alias.CustomAlias
 name: CustomAlias
 config:
     locations:
-        md: metadata
-        static: static
+        md: "{{ satosa_metadata_dir }}"
+        static: "{{ satosa_static_dir }}"

--- a/roles/satosa/templates/custom_logging_service.yaml.j2
+++ b/roles/satosa/templates/custom_logging_service.yaml.j2
@@ -1,6 +1,6 @@
 module: satosa.micro_services.custom_logging.CustomLoggingService
 name: CustomLoggingService
 config:
-  log_target: 'var/custom.log'
+  log_target: "{{ satosa_log_dir }}/custom.log"
   attrs: ['uid', 'eduPersonPrincipalName','eduPersonTargetedID']
 

--- a/roles/satosa/templates/gen_metadata.j2
+++ b/roles/satosa/templates/gen_metadata.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "{{ satosa_env_dir }}/bin/activate"
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+"{{ satosa_env_dir }}/bin/satosa-saml-metadata" --split-module proxy_conf.yaml "{{ satosa_env_dir }}/certs/signing.key" "{{ satosa_env_dir }}/certs/signing.crt" --dir $@

--- a/roles/satosa/templates/saml2_backend.yaml.j2
+++ b/roles/satosa/templates/saml2_backend.yaml.j2
@@ -78,7 +78,6 @@ config:
           - urn:oid:2.5.4.42
           # surname
           - urn:oid:2.5.4.4
-    attribute_map_dir: '{{ satosa_env_dir }}/mapper'
     allow_unknown_attributes: true
   # disco_srv must be defined if there is more than one IdP in the metadata specified above
   disco_srv: {{http_proto}}://{{ hostnames.mdq }}/role/idp.ds

--- a/roles/satosa/templates/saml2_frontend.yaml.j2
+++ b/roles/satosa/templates/saml2_frontend.yaml.j2
@@ -62,7 +62,6 @@ config:
             fail_on_missing_requested: false
             lifetime: {minutes: 15}
             #name_form: urn:oasis:names:tc:SAML:2.0:attrname-format:basic
-    attribute_map_dir: '{{ satosa_env_dir }}/mapper'
     allow_unknown_attributes: true
   acr_mapping:
     "": default-LoA

--- a/roles/satosa/templates/saml2_mirrorbackend.yaml.j2
+++ b/roles/satosa/templates/saml2_mirrorbackend.yaml.j2
@@ -26,7 +26,6 @@ config:
         name_id_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
         name_id_format_allow_create: True
         want_response_signed: false
-    attribute_map_dir: '{{ satosa_env_dir }}/mapper'
     allow_unknown_attributes: true
   # disco_srv must be defined if there is more than one IdP in the metadata specified above
   disco_srv: https://{{ hostnames.mdq }}/role/idp.ds

--- a/roles/satosa/templates/saml2_mirrorfrontend.yaml.j2
+++ b/roles/satosa/templates/saml2_mirrorfrontend.yaml.j2
@@ -24,7 +24,6 @@ config:
             fail_on_missing_requested: false
             lifetime: {minutes: 15}
             #name_form: urn:oasis:names:tc:SAML:2.0:attrname-format:basic
-    attribute_map_dir: '{{ satosa_env_dir }}/mapper'
     allow_unknown_attributes: true
   acr_mapping:
     "": default-LoA


### PR DESCRIPTION
As we now rely on a fixed version of pysaml2, we can remove the empty mapper dir work-around. This PR also fixes correct default SATOSA branch.