### PR TITLE
Add ES-curator config to prune indices

### DIFF
--- a/roles/syslog-server/files/curator.yml
+++ b/roles/syslog-server/files/curator.yml
@@ -1,0 +1,20 @@
+---
+client:
+  hosts:
+    - 127.0.0.1
+  port: 9200
+  url_prefix:
+  use_ssl: False
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth:
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/roles/syslog-server/files/curator_actions.yml
+++ b/roles/syslog-server/files/curator_actions.yml
@@ -1,0 +1,21 @@
+---
+actions:
+  1:
+    action: delete_indices
+    description: >-
+      Delete indices older than 30 days (based on index name), for logstash-
+      prefixed indices. Ignore the error if the filter does not result in an
+      actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      disable_action: false
+    filters:
+      - filtertype: pattern
+        kind: prefix
+        value: logstash-
+      - filtertype: age
+        source: name
+        direction: older
+        timestring: '%Y%m%d'
+        unit: days
+        unit_count: 30

--- a/roles/syslog-server/tasks/main.yaml
+++ b/roles/syslog-server/tasks/main.yaml
@@ -22,14 +22,19 @@
     - elasticsearch
     - logstash
     - kibana
+    - elasticsearch-curator
 
 - name: Ensure Elasticsearch data directory exists
   file: path=/var/elasticsearch state=directory mode=0750 owner=elasticsearch
 
 - name: Copy elasticsearch configuration file
   copy:
-    src: elasticsearch.yml
-    dest: /etc/elasticsearch/elasticsearch.yml
+    src: "{{ item }}"
+    dest: "/etc/elasticsearch/{{ item }}"
+  with_items:
+    - elasticsearch.yml
+    - curator.yml
+    - curator_actions.yml
   notify: restart elasticsearch
 
 - name: Copy logstash configuration file
@@ -43,4 +48,3 @@
     src: kibana.yml
     dest: /etc/kibana/kibana.yml
   notify: restart kibana
-


### PR DESCRIPTION
Indices can now be pruned (30 days) using
```
curator --config /etc/elasticsearch/curator.yml --dry-run /etc/elasticsearch/curator_actions.yml
```