### PR TITLE
Add collectd metrics logging

### DIFF
--- a/roles/syslog-client/defaults/main.yml
+++ b/roles/syslog-client/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 use_logserver: true
+external_ping: "195.176.255.9"

--- a/roles/syslog-client/files/scz-logging.service
+++ b/roles/syslog-client/files/scz-logging.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=SCZ Logging Runner
+
+[Service]
+User=root
+Group=root
+Type=oneshot
+ExecStart=/bin/run-parts --verbose --new-session --umask=077 --regex='.*\\.sh' -- '/opt/logging/run.d'

--- a/roles/syslog-client/files/scz-logging.timer
+++ b/roles/syslog-client/files/scz-logging.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=SCZ logging timer
+
+[Timer]
+OnCalendar=*-*-* *:00:00
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/syslog-client/files/upgradeable
+++ b/roles/syslog-client/files/upgradeable
@@ -1,0 +1,8 @@
+#!/bin/sh
+HOSTNAME="${COLLECTD_HOSTNAME:-localhost}"
+INTERVAL="${COLLECTD_INTERVAL:-60}"
+
+while sleep "$INTERVAL"; do
+   VALUE=`apt list --upgradeable 2>/dev/null | grep -ve '^Listing' | wc -l`
+   echo "PUTVAL \"$HOSTNAME/apt/gauge-upgradeable\" interval=$INTERVAL N:$VALUE"
+done

--- a/roles/syslog-client/handlers/main.yml
+++ b/roles/syslog-client/handlers/main.yml
@@ -15,3 +15,7 @@
 - name: start collectd Service
   service: name=collectd state=restarted enabled=yes
   when: use_logserver
+
+- name: start logging Service
+  service: name=scz-logging.timer state=restarted enabled=yes
+  when: use_logserver

--- a/roles/syslog-client/handlers/main.yml
+++ b/roles/syslog-client/handlers/main.yml
@@ -12,3 +12,6 @@
   service: name=filebeat state=restarted enabled=yes
   when: use_logserver
 
+- name: start collectd Service
+  service: name=collectd state=restarted enabled=yes
+  when: use_logserver

--- a/roles/syslog-client/tasks/main.yaml
+++ b/roles/syslog-client/tasks/main.yaml
@@ -3,6 +3,9 @@
 - name: Ensure filebeat include dir exists
   file: path=/etc/filebeat/conf.d state=directory mode=0750
 
+- name: Ensure generic logging run dir exists
+  file: path=/opt/logging/run.d state=directory mode=0750
+
 - block:
 
     - name: Ensure that apt-transport-https is installed
@@ -46,5 +49,23 @@
         src: collectd.conf.j2
         dest: /etc/collectd/collectd.conf
       notify: start collectd Service
+
+    - name: Copy systemd generic (hourly) logging timer
+      copy:
+        src: scz-logging.timer
+        dest: /etc/systemd/system/scz-logging.timer
+
+    - name: Copy systemd generic logging service
+      copy:
+        src: scz-logging.service
+        dest: /etc/systemd/system/scz-logging.service
+      notify: start logging Service
+
+    - name: Copy loggers
+      template:
+        src: "{{ item }}.j2"
+        dest: "/opt/logging/run.d/{{ item }}"
+      with_items:
+        - iptables.sh
 
   when: use_logserver

--- a/roles/syslog-client/tasks/main.yaml
+++ b/roles/syslog-client/tasks/main.yaml
@@ -27,6 +27,7 @@
         install_recommends: no
       with_items:
         - filebeat
+        - collectd
 
     - name: Create generic filebeat conf
       template: >
@@ -39,5 +40,11 @@
         src: fb_syslog.yml.j2
         dest: /etc/filebeat/conf.d/fb_syslog.yml
       when: false
+
+    - name: Copy collectd config
+      template:
+        src: collectd.conf.j2
+        dest: /etc/collectd/collectd.conf
+      notify: start collectd Service
 
   when: use_logserver

--- a/roles/syslog-client/tasks/main.yaml
+++ b/roles/syslog-client/tasks/main.yaml
@@ -31,6 +31,7 @@
       with_items:
         - filebeat
         - collectd
+        - liboping0
 
     - name: Create generic filebeat conf
       template: >

--- a/roles/syslog-client/templates/collectd.conf.j2
+++ b/roles/syslog-client/templates/collectd.conf.j2
@@ -14,6 +14,7 @@ LoadPlugin iptables
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin network
+LoadPlugin ping
 <Plugin df>
         FSType rootfs
         FSType sysfs
@@ -33,6 +34,11 @@ LoadPlugin network
 </Plugin>
 <Plugin network>
         Server "{{ servers.syslog }}" "25826"
+</Plugin>
+<Plugin ping>
+        Host "{{ servers.syslog }}"
+        Host "{{ servers.dns[0] }}"
+        Host "{{ external_ping }}"
 </Plugin>
 <Include "/etc/collectd/collectd.conf.d">
         Filter "*.conf"

--- a/roles/syslog-client/templates/collectd.conf.j2
+++ b/roles/syslog-client/templates/collectd.conf.j2
@@ -15,6 +15,7 @@ LoadPlugin load
 LoadPlugin memory
 LoadPlugin network
 LoadPlugin ping
+LoadPlugin uptime
 <Plugin df>
         FSType rootfs
         FSType sysfs

--- a/roles/syslog-client/templates/collectd.conf.j2
+++ b/roles/syslog-client/templates/collectd.conf.j2
@@ -1,0 +1,31 @@
+FQDNLookup false
+Interval 60
+LoadPlugin syslog
+<Plugin syslog>
+        LogLevel info
+</Plugin>
+LoadPlugin cpu
+LoadPlugin df
+LoadPlugin disk
+LoadPlugin entropy
+LoadPlugin interface
+LoadPlugin load
+LoadPlugin memory
+LoadPlugin network
+<Plugin df>
+        FSType rootfs
+        FSType sysfs
+        FSType proc
+        FSType devtmpfs
+        FSType devpts
+        FSType tmpfs
+        FSType fusectl
+        FSType cgroup
+        IgnoreSelected true
+</Plugin>
+<Plugin network>
+        Server "{{ servers.syslog }}" "25826"
+</Plugin>
+<Include "/etc/collectd/collectd.conf.d">
+        Filter "*.conf"
+</Include>

--- a/roles/syslog-client/templates/collectd.conf.j2
+++ b/roles/syslog-client/templates/collectd.conf.j2
@@ -10,6 +10,7 @@ LoadPlugin disk
 LoadPlugin entropy
 LoadPlugin exec
 LoadPlugin interface
+LoadPlugin iptables
 LoadPlugin load
 LoadPlugin memory
 LoadPlugin network
@@ -26,6 +27,9 @@ LoadPlugin network
 </Plugin>
 <Plugin exec>
         Exec _apt "/usr/local/bin/upgradeable"
+</Plugin>
+<Plugin iptables>
+        Chain "filter" "INPUT" 1
 </Plugin>
 <Plugin network>
         Server "{{ servers.syslog }}" "25826"

--- a/roles/syslog-client/templates/collectd.conf.j2
+++ b/roles/syslog-client/templates/collectd.conf.j2
@@ -8,6 +8,7 @@ LoadPlugin cpu
 LoadPlugin df
 LoadPlugin disk
 LoadPlugin entropy
+LoadPlugin exec
 LoadPlugin interface
 LoadPlugin load
 LoadPlugin memory
@@ -22,6 +23,9 @@ LoadPlugin network
         FSType fusectl
         FSType cgroup
         IgnoreSelected true
+</Plugin>
+<Plugin exec>
+        Exec _apt "/usr/local/bin/upgradeable"
 </Plugin>
 <Plugin network>
         Server "{{ servers.syslog }}" "25826"

--- a/roles/syslog-client/templates/iptables.sh.j2
+++ b/roles/syslog-client/templates/iptables.sh.j2
@@ -1,0 +1,5 @@
+ #!/bin/bash
+IPTABLES=`/sbin/iptables -t filter -S INPUT`
+VALUE=${IPTABLES//$'\n'/"\n"}
+MSG="{ \"hostname\": \"proxy1\" , \"source\": \"iptables\", \"message\": \"$VALUE\" }"
+curl -s -H "content-type: application/json" -XPUT 'http://{{ servers.syslog }}:8080/' -d "$MSG" > /dev/null

--- a/roles/syslog-server/files/logstash.conf
+++ b/roles/syslog-server/files/logstash.conf
@@ -60,7 +60,7 @@ filter {
     }
     if [collectd_type] {
         mutate {
-            remove_field => [ "host" ]
+            rename => { "host" => "[host][name]" }
         }
     }
 }

--- a/roles/syslog-server/files/logstash.conf
+++ b/roles/syslog-server/files/logstash.conf
@@ -6,6 +6,16 @@ input {
     }
 }
 
+input {
+    udp {
+        port => 25826
+        buffer_size => 1452
+        codec => collectd {
+            typesdb => [ '/usr/share/collectd/types.db']
+        }
+    }
+}
+
 filter {
     if [source] == "satosa" {
         json {
@@ -48,6 +58,11 @@ filter {
             match => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss" ]
         }
     }
+    if [collectd_type] {
+        mutate {
+            remove_field => [ "host" ]
+        }
+    }
 }
 
 output {
@@ -56,3 +71,5 @@ output {
         index => "logstash-%{+YYYYMMdd}"
     }
 }
+
+#output { stdout { codec => rubydebug } }

--- a/roles/syslog-server/tasks/main.yaml
+++ b/roles/syslog-server/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure that apt-transport-https and openjdk-8-jdk are installed
+- name: Ensure that openjdk-8-jdk is installed
   apt:
     name: "{{ item }}"
   with_items:
@@ -22,6 +22,7 @@
     - elasticsearch
     - logstash
     - kibana
+    - collectd
 
 - name: Ensure Elasticsearch data directory exists
   file: path=/var/elasticsearch state=directory mode=0750 owner=elasticsearch
@@ -44,3 +45,5 @@
     dest: /etc/kibana/kibana.yml
   notify: restart kibana
 
+- name: Disable collectd service
+  systemd: name=collectd state=stopped enabled=no


### PR DESCRIPTION
Since metricbeats doesn't potentially fullill our requirements I tried a collectd version of the metrics collection. I need collectd package on the server for /usr/share/collectd/types.db and disable the service, but we might want to collect metrics from stats server as well, which bites the disabling of the service?