### PR TITLE
Client Zabbix-agent package and configuration

### DIFF
--- a/provision.yml
+++ b/provision.yml
@@ -36,6 +36,7 @@
     - { role: mail,          tags: ['common','mail']     }
     - { role: syslog-client, tags: ['common','syslog']   }
     - { role: backups,       tags: ['common','backups']  }
+    - { role: zabbix-agent,  tags: ['common','zabbix']   }
 
 - hosts: mgnt1
   roles:

--- a/roles/zabbix-agent/handlers/main.yaml
+++ b/roles/zabbix-agent/handlers/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: restart zabbix-agent
+  service:  name=zabbix-agent state=restarted
+  listen: "restart zabbix-agent"

--- a/roles/zabbix-agent/tasks/main.yaml
+++ b/roles/zabbix-agent/tasks/main.yaml
@@ -1,0 +1,38 @@
+---
+
+- name: Ensure that packages are installed
+  apt:
+    name:
+      - zabbix-agent
+    state: present
+    install_recommends: no
+
+- name: Default configuration
+  template: >
+    src=default.conf.j2
+    dest=/etc/zabbix/zabbix_agentd.conf.d/default.conf
+  notify: restart zabbix-agent
+
+- name: Register Host
+  local_action:
+    module: zabbix_host
+    server_url: https://zabbix.scz.lab.surf.nl/
+    login_user: Admin
+    login_password: zabbix
+    host_name: "{{ inventory_hostname }}"
+    host_groups:
+      - "{{ environment_name }}"
+    link_templates:
+      - Template OS Linux
+    status: enabled
+    state: present
+    interfaces:
+      - type: 1
+        main: 1
+        useip: 1
+        ip: "{{ ansible_default_ipv4.address }}"
+        dns: ""
+        port: 10050
+
+
+

--- a/roles/zabbix-agent/templates/default.conf.j2
+++ b/roles/zabbix-agent/templates/default.conf.j2
@@ -1,0 +1,3 @@
+Server=mgnt2.ams.scz.lab.surf.nl
+ServerActive=mgnt2.ams.scz.lab.surf.nl
+Hostname={{ inventory_hostname }}


### PR DESCRIPTION
This requires ```pip install zabbix-api``` on the **_host_** from where the ansible deploy is run.
