### PR TITLE
Client Zabbix-agent package and configuration

### DIFF
--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -107,3 +107,6 @@ comanage_proxy_attribute: "cmuid"
 
 php_debug: true
 php_xdebug_host: "{{iprange.bastion}}"
+
+# No Zabbix on VM/Travis
+zabbix_enabled: false

--- a/provision.yml
+++ b/provision.yml
@@ -36,6 +36,7 @@
     - { role: mail,          tags: ['common','mail']     }
     - { role: syslog-client, tags: ['common','syslog']   }
     - { role: backups,       tags: ['common','backups']  }
+    - { role: zabbix-agent,  tags: ['common','zabbix']   }
 
 - hosts: mgnt1
   roles:

--- a/roles/zabbix-agent/files/count_upgradeable
+++ b/roles/zabbix-agent/files/count_upgradeable
@@ -1,0 +1,7 @@
+#!/bin/sh
+# All updates
+/usr/bin/aptitude search '~U' | wc -l
+
+# Only security updates
+#/usr/bin/aptitude search '?and(~U,~Asecurity)' | wc -l
+

--- a/roles/zabbix-agent/handlers/main.yaml
+++ b/roles/zabbix-agent/handlers/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: restart zabbix-agent
+  service:  name=zabbix-agent state=restarted
+  listen: "restart zabbix-agent"

--- a/roles/zabbix-agent/tasks/main.yaml
+++ b/roles/zabbix-agent/tasks/main.yaml
@@ -1,0 +1,37 @@
+---
+
+- block:
+    - name: Ensure that packages are installed
+      apt:
+        name:
+          - zabbix-agent
+        state: present
+        install_recommends: no
+
+    - name: Default configuration
+      template: >
+        src=default.conf.j2
+        dest=/etc/zabbix/zabbix_agentd.conf.d/default.conf
+      notify: restart zabbix-agent
+
+    - name: Register Host
+      local_action:
+        module: zabbix_host
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_server_admin }}"
+        login_password: "{{ zabbix_server_admin_pwd }}"
+        host_name: "{{ inventory_hostname }}"
+        host_groups:
+          - "{{ environment_name }}"
+        link_templates:
+          - "Template OS Linux"
+        status: enabled
+        state: present
+        interfaces:
+          - type: 1
+            main: 1
+            useip: 1
+            ip: "{{ ansible_default_ipv4.address }}"
+            dns: ""
+            port: 10050
+  when: zabbix_enabled

--- a/roles/zabbix-agent/tasks/main.yaml
+++ b/roles/zabbix-agent/tasks/main.yaml
@@ -14,6 +14,12 @@
         dest=/etc/zabbix/zabbix_agentd.conf.d/default.conf
       notify: restart zabbix-agent
 
+    - name: Count upgradeable packages
+      copy:
+        src: count_upgradeable
+        dest: /usr/local/sbin/count_upgradeable
+        mode: 0755
+
     - name: Register Host
       local_action:
         module: zabbix_host

--- a/roles/zabbix-agent/templates/default.conf.j2
+++ b/roles/zabbix-agent/templates/default.conf.j2
@@ -1,0 +1,3 @@
+Server={{ groups['mgnt2'][0] }}
+ServerActive={{ groups['mgnt2'][0] }}
+Hostname={{ inventory_hostname }}

--- a/roles/zabbix-agent/templates/default.conf.j2
+++ b/roles/zabbix-agent/templates/default.conf.j2
@@ -1,3 +1,5 @@
 Server={{ groups['mgnt2'][0] }}
 ServerActive={{ groups['mgnt2'][0] }}
 Hostname={{ inventory_hostname }}
+EnableRemoteCommands=1
+Timeout=10


### PR DESCRIPTION
This requires ```pip install zabbix-api``` on the **_host_** from where the ansible deploy is ran.