### PR TITLE
Fix to prevent configuration of a firewall in the case of VMs. 

### DIFF
--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -23,4 +23,4 @@
     - name: Start and enable netfilter-persistent
       service: name=netfilter-persistent.service state=started enabled="yes"
 
-  when: ansible_virtualization_type != "docker"
+  when: environment_name != 'vm'


### PR DESCRIPTION
This was previously blocked only for Docker configuration. This fix is non-backward compatible in the sense that it would enable firewalling if docker were to be used in a test or pilot environment, but that is not (yet) the case.