### PR TITLE
Enable haproxy http2 on frontend

### DIFF
--- a/roles/https_haproxy/tasks/main.yml
+++ b/roles/https_haproxy/tasks/main.yml
@@ -26,6 +26,12 @@
   notify:
     - restart haproxy
 
+- name: install haproxy config
+  template: src=crt-list.txt.j2 dest=/etc/haproxy/crt-list.txt mode=0644 owner=root group=root
+  notify:
+    - restart haproxy
+  when: enable_https
+
 - name: enable haproxy
   systemd: daemon_reload=yes name=haproxy state=started enabled=true
 

--- a/roles/https_haproxy/templates/crt-list.txt.j2
+++ b/roles/https_haproxy/templates/crt-list.txt.j2
@@ -1,0 +1,2 @@
+{% set lb_http  = loadbalancer|selectattr("http")|list %}
+{% for host in lb_http %} {{host.hostname}}/priv+fullchain.pem {{host.hostname}}{% endfor %}

--- a/roles/https_haproxy/templates/haproxy.cfg.j2
+++ b/roles/https_haproxy/templates/haproxy.cfg.j2
@@ -46,8 +46,8 @@ defaults
 # -------------------------------------------------------------------
 frontend fe_https
 {% if enable_https %}
-	bind    *:443 ssl {% for host in lb_http %} crt {{host.hostname}}/priv+fullchain.pem{% endfor %} transparent
-	bind [::]:443 ssl {% for host in lb_http %} crt {{host.hostname}}/priv+fullchain.pem{% endfor %} transparent
+	bind    *:443 ssl crt-list /etc/haproxy/crt-list.txt transparent alpn h2,http/1.1
+	bind [::]:443 ssl crt-list /etc/haproxy/crt-list.txt transparent alpn h2,http/1.1
 {% else %}
 	bind    *:80 transparent
 	bind [::]:80 transparent

--- a/roles/slp/tasks/main.yml
+++ b/roles/slp/tasks/main.yml
@@ -64,20 +64,20 @@
     dest: "/usr/local/bin/provisioning.sh"
     state: absent
 
+- name: check if crontab exists
+  stat:
+    path: "/etc/logrotate.d/provisioning"
+  register: crontab
+
 # replaced by systemd time
 - name: Remove obsolete cronjob
   cron:
     name: "SBS Provisioning"
     state: absent
-
-- name: check if crontab exists
-  stat:
-    path: "/etc/logrotate.d/provisioning"
-  register: crontab
+  when: crontab.stat.exists
 
 # replaced by systemd/journald logs
 - name: Remove obsolete logrotate configuration
   file:
     dest: "/etc/logrotate.d/provisioning"
     state: absent
-  when: crontab.stat.exists


### PR DESCRIPTION
This PR enables http2 on haproxy for Debian buster