### PR TITLE
Fix mirrorfrontend mdq url

### DIFF
--- a/roles/satosa/templates/saml2_backend.yaml.j2
+++ b/roles/satosa/templates/saml2_backend.yaml.j2
@@ -21,7 +21,7 @@ config:
 {% endfor %}
 {% endfor %}
     metadata:
-      mdq: ['https://{{ hostnames.mdq }}']
+      mdq: ['https://{{ hostnames.mdq }}/']
     entityid: <base_url>/md/<name>.xml
     entity_category:
       - 'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'

--- a/roles/satosa/templates/saml2_mirrorbackend.yaml.j2
+++ b/roles/satosa/templates/saml2_mirrorbackend.yaml.j2
@@ -10,7 +10,7 @@ config:
     - {contact_type: technical, email_address: technical@{{ hostnames.proxy }}, given_name: Technical}
     - {contact_type: support, email_address: support@{{ hostnames.proxy }}, given_name: Support}
     metadata:
-      mdq: ['https://{{ hostnames.mdq }}']
+      mdq: ['https://{{ hostnames.mdq }}/']
     entityid: <base_url>/md/<name>.xml
     entity_category:
       - 'http://www.geant.net/uri/dataprotection-code-of-conduct/v1'

--- a/roles/satosa/templates/saml2_mirrorfrontend.yaml.j2
+++ b/roles/satosa/templates/saml2_mirrorfrontend.yaml.j2
@@ -9,7 +9,7 @@ config:
     key_file: certs/frontend.key
     cert_file: certs/frontend.crt
     metadata:
-      mdq: ['http://localhost:{{ pyff_port }}']
+      mdq: ['https://{{ hostnames.mdq }}/']
     entityid: <base_url>/md/<name>.xml
     ignore_requested_attributes: true
     service:


### PR DESCRIPTION
For some reason, SATOSA sometimes falls back on MirroredFrontend configuration to check incoming authnRequests. This failed because of the incorrect mdq endpoint in that frontend (although barely used). Linked to PR #119 Adding trailing slashes while we're at it.