### PR TITLE
Fix pam-websso

### DIFF
--- a/docker/docker-compose.yml.py
+++ b/docker/docker-compose.yml.py
@@ -23,6 +23,7 @@ logical_hosts = [
     'proxy',    'mdq',         'cm',        'comanage',
     'ldap',     'meta',        'oidc-test', 'sp-test',
     'idp-test', 'google-test', 'sbs',       'sandbox1',
+    'pam',
 ]
 
 subnet = '172.20.1'

--- a/environments/vm/group_vars/ldap.yml
+++ b/environments/vm/group_vars/ldap.yml
@@ -5,3 +5,6 @@ firewall_v4_incoming:
   #- { name: comanage,     src: "{{iprange.comanage}}", dport:                   "389", proto: tcp }
   - { name: loadbalancer, src: "{{iprange.lb}}",       dport:  "{{pam_clients_port}}", proto: tcp }
   - { name: vnet,         src: "{{iprange.vm}}",       dport:                "22,389", proto: tcp }
+
+pam_host: "0.0.0.0"
+pam_clients_port: 8087

--- a/environments/vm/group_vars/vm.yml
+++ b/environments/vm/group_vars/vm.yml
@@ -37,7 +37,7 @@ metadata_backend_port: 88
 comanage_backend_port: 89
 sbs_backend_port: 90
 tfa_test_port: 91
-pam_clients_port: 8087
+pam_backend_port: 92
 meta_port: 88
 
 # COmanage-ldap configuration
@@ -109,7 +109,7 @@ loadbalancer:
   - hostname: "{{hostnames.pam}}"
     protocol: http
     backend_hosts: "{{groups['vm_ldap']}}"
-    backend_port: "{{pam_clients_port}}"
+    backend_port: "{{pam_backend_port}}"
   - hostname: "{{hostnames.ldap}}"
     protocol: ldap
     frontend_port: 636

--- a/roles/pam_websso_daemon/handlers/main.yml
+++ b/roles/pam_websso_daemon/handlers/main.yml
@@ -5,3 +5,8 @@
     state: "restarted"
     enabled: true
     daemon_reload: true
+
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted

--- a/roles/pam_websso_daemon/tasks/main.yml
+++ b/roles/pam_websso_daemon/tasks/main.yml
@@ -35,3 +35,6 @@
     src: websso-daemon.service.j2
     dest: "/etc/systemd/system/websso-daemon.service"
     mode: 0644
+
+- name: set up nxginx proxy
+  include: nginx.yml

--- a/roles/pam_websso_daemon/tasks/nginx.yml
+++ b/roles/pam_websso_daemon/tasks/nginx.yml
@@ -1,0 +1,25 @@
+# installs nginx to handle static file and reverse-proxy chrerrypy
+---
+- name: install NGINX
+  apt:
+    name: nginx
+    state: present
+
+- name: remove default NGINX sites
+  file:
+    dest: /etc/nginx/sites-enabled/default
+    state: absent
+  notify: restart nginx
+
+- name: install NGINX config file
+  template:
+    src: nginx-pam.conf.j2
+    dest: /etc/nginx/sites-enabled/00-pam.conf
+  notify: restart nginx
+
+- name: enable NGINX
+  service:
+    name: nginx
+    state: started
+    enabled: true
+

--- a/roles/pam_websso_daemon/templates/nginx-pam.conf.j2
+++ b/roles/pam_websso_daemon/templates/nginx-pam.conf.j2
@@ -1,0 +1,18 @@
+server {
+	listen {{pam_host}}:{{pam_backend_port}} default_server ssl;
+
+    ssl_certificate     {{ ssl_certs_dir }}/{{ internal_base_domain }}.crt;
+    ssl_certificate_key {{ ssl_certs_dir }}/{{ internal_base_domain }}.key;
+    ssl_protocols       TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+	server_name _;
+
+	location / {
+		proxy_pass         http://0.0.0.0:{{pam_clients_port}};
+		proxy_redirect     off;
+		proxy_pass_request_headers on;
+		proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+}
+


### PR DESCRIPTION
This fixes the pam-websso demo, but still requires ```/etc/nslcd.conf``` to contain an existing basedn to resolve existing users in ldap e.g:

```
# The search base that will be used for all queries.
base dc=flat,dc=https://sp-test.scz-vm.net/saml/module.php/saml/sp/metadata.php/default-sp,dc=services,dc=vnet
```
This is analogue to what a conventional SSH service would need to configure.