### PR TITLE
Add index for entryUUID

### DIFF
--- a/roles/ldap_services/templates/set_root_credentials.ldif.j2
+++ b/roles/ldap_services/templates/set_root_credentials.ldif.j2
@@ -35,3 +35,6 @@ olcAccess: to dn.regex="(([^,]+),{{ services_ldap.basedn }})$"
   by dn.exact="{{ services_ldap.binddn }}" write
   by dn.exact,expand="cn=admin,$1" read
   by * break
+-
+add: olcDbIndex
+olcDbIndex: entryUUID eq


### PR DESCRIPTION
Deployed and checked:
```
root@ldap2:/etc/ldap/slapd.d/cn=config# cat olcDatabase\=\{1\}mdb.ldif 
# AUTO-GENERATED FILE - DO NOT EDIT!! Use ldapmodify.
# CRC32 eba6bb71
dn: olcDatabase={1}mdb
objectClass: olcDatabaseConfig
objectClass: olcMdbConfig
olcDatabase: {1}mdb
olcDbDirectory: /var/lib/ldap
olcLastMod: TRUE
olcDbCheckpoint: 512 30
olcDbIndex: objectClass eq
olcDbIndex: cn,uid eq
olcDbIndex: uidNumber,gidNumber eq
olcDbIndex: member,memberUid eq
olcDbIndex: entryUUID eq
...
```