### PR TITLE
Python needs explicit ca-cert location for self-signed cert

### DIFF
--- a/roles/plsc/templates/plsc.service.j2
+++ b/roles/plsc/templates/plsc.service.j2
@@ -5,6 +5,7 @@ Description=PLSC Runner
 User=root
 Group=root
 Type=oneshot
+Environment="REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 WorkingDirectory={{ plsc_dir }}
 ExecStart={{ plsc_dir }}/run plsc.yml
 RuntimeMaxSec=120


### PR DESCRIPTION
plsc won't work on docker deploy without this fix