### PR TITLE
Fix index landingpage for eduTEAMS SRAM proxy metadata endpoints

### DIFF
--- a/roles/metadata/templates/index.html.j2
+++ b/roles/metadata/templates/index.html.j2
@@ -1,6 +1,11 @@
 <html>
 <title>SRAM</title>
 <body>
-    Placeholder for SRAM metadata
+
+<h2>SRAM metadata</h2>
+<p><a href='{{ proxy_metadata_baseurl }}/frontend.xml'>SRAM IdP proxy metadata</a><br>
+(for use by Service Providers)</p>
+<p><a href='{{ proxy_metadata_baseurl }}/backend.xml'>SRAM SP proxy metadata</a><br>
+(for use by Identity Providers)</p>
 </body>
 </html>


### PR DESCRIPTION
This adds some extra text and links to explain what metadata to downoad for SP's and IdP's connecting to SRAM using the eduTEAMS proxy.