### PR TITLE
Add metadata source dir to pyff-metadata feed

### DIFF
--- a/roles/pyff-metadata/defaults/main.yml
+++ b/roles/pyff-metadata/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 metadata_idps_xrd: "{{pyff_env_dir}}/certs/surfconext.xrd"
 metadata_idps_targetfile: "{{pyff_metadata_dir}}/idps.xml"
+metadata_source_dir : "/opt/metadata-src"
 
 metadata_idps_feed: "https://metadata.surfconext.nl/idps-metadata.xml"
 metadata_idps_cert: |

--- a/roles/pyff-metadata/defaults/main.yml
+++ b/roles/pyff-metadata/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 metadata_idps_xrd: "{{pyff_env_dir}}/certs/surfconext.xrd"
 metadata_idps_targetfile: "{{pyff_metadata_dir}}/idps.xml"
-metadata_source_dir : "/opt/metadata-src"
+metadata_source_dir: "/opt/metadata-src"
 
 metadata_idps_feed: "https://metadata.surfconext.nl/idps-metadata.xml"
 metadata_idps_cert: |

--- a/roles/pyff-metadata/tasks/main.yml
+++ b/roles/pyff-metadata/tasks/main.yml
@@ -13,9 +13,9 @@
 - name: Create metadata source directory
   file:
     path: "{{ metadata_source_dir }}"
-    state: directory
-    mode: 0755
-    owner: pyff
+    state: "directory"
+    mode: "0755"
+    owner: "root"
 
 - name: Create pyFF mdq configuration
   template:

--- a/roles/pyff-metadata/tasks/main.yml
+++ b/roles/pyff-metadata/tasks/main.yml
@@ -10,6 +10,13 @@
     dest: "{{metadata_idps_xrd}}"
   notify: "run pyff-metadata job"
 
+- name: Create metadata source directory
+  file:
+    path: "{{ metadata_source_dir }}"
+    state: directory
+    mode: 0755
+    owner: pyff
+
 - name: Create pyFF mdq configuration
   template:
     src: "idp_feed.fd.j2"

--- a/roles/pyff-metadata/templates/idp_feed.fd.j2
+++ b/roles/pyff-metadata/templates/idp_feed.fd.j2
@@ -1,5 +1,6 @@
 - load:
    - {{metadata_idps_xrd}}
+   - {{metadata_source_dir}}
 - select:
 {% for f in metadata_idps_filters %}
   - "{{f}}"


### PR DESCRIPTION
This adds the ability to add extra entityID's at will, without re-deploying pyff-metadata